### PR TITLE
Build with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,16 +23,17 @@ set (GEN_HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
 include_directories(include)
 include_directories(${GEN_HEADER_DIR})
 
-if (NOT CMAKE_CROSSCOMPILING)
-add_executable(buildheader CONFIG/buildheader.c)
-endif()
 
 file(MAKE_DIRECTORY ${GEN_HEADER_DIR})
 add_custom_command(OUTPUT ${GEN_HEADER_DIR}/vrb.h 
                    COMMAND buildheader ${GEN_HEADER_DIR}/vrb.h ${SOURCE_FILES}
-                   DEPENDS buildheader 
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_custom_target(generate_header ALL DEPENDS ${GEN_HEADER_DIR}/vrb.h)
+
+if (NOT CMAKE_CROSSCOMPILING)
+add_executable(buildheader CONFIG/buildheader.c)
+add_dependencies(generate_header buildheader)
+endif()
 
 add_library(vrb SHARED ${SOURCE_FILES})
 add_dependencies(vrb generate_header)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+include (GNUInstallDirs)
 
 set (SOURCE_FILES
     vrb/src/lib/vrb/vrb_destroy.c
@@ -33,6 +34,7 @@ add_custom_target(generate_header ALL DEPENDS ${GEN_HEADER_DIR}/vrb.h)
 if (NOT CMAKE_CROSSCOMPILING)
 add_executable(buildheader CONFIG/buildheader.c)
 add_dependencies(generate_header buildheader)
+install(FILES ${GEN_HEADER_DIR}/vrb.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 
 add_library(vrb SHARED ${SOURCE_FILES})
@@ -41,9 +43,9 @@ add_dependencies(vrb generate_header)
 add_executable(vbuf vrb/src/bin/vbuf.c)
 target_link_libraries(vbuf vrb)
 
-install(TARGETS vrb DESTINATION /usr/lib)
-install(TARGETS vbuf DESTINATION /usr/bin)
+install(TARGETS vrb DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS vbuf DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 if (NOT CMAKE_CROSSCOMPILING)
-install(TARGETS buildheader DESTINATION /usr/bin)
+install(TARGETS buildheader DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-include_directories(include)
 
 set (SOURCE_FILES
     vrb/src/lib/vrb/vrb_destroy.c
@@ -19,14 +18,22 @@ set (SOURCE_FILES
     vrb/src/lib/vrb/vrb_write.c
     )
 
+set (GEN_HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
+
+include_directories(include)
+include_directories(${GEN_HEADER_DIR})
+
 add_executable(buildheader CONFIG/buildheader.c)
 
-add_custom_command(OUTPUT include/vrb.h 
-                   COMMAND buildheader include/vrb.h ${SOURCE_FILES} 
+file(MAKE_DIRECTORY ${GEN_HEADER_DIR})
+add_custom_command(OUTPUT ${GEN_HEADER_DIR}/vrb.h 
+                   COMMAND buildheader ${GEN_HEADER_DIR}/vrb.h ${SOURCE_FILES}
                    DEPENDS buildheader 
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_custom_target(generate_header ALL DEPENDS ${GEN_HEADER_DIR}/vrb.h)
 
-add_library(libvrb SHARED ${SOURCE_FILES} include/vrb.h)
+add_library(libvrb SHARED ${SOURCE_FILES})
+add_dependencies(libvrb generate_header)
 
 add_executable(vbuf vrb/src/bin/vbuf.c)
 target_link_libraries(vbuf libvrb)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,9 @@ set (GEN_HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
 include_directories(include)
 include_directories(${GEN_HEADER_DIR})
 
+if (NOT CMAKE_CROSSCOMPILING)
 add_executable(buildheader CONFIG/buildheader.c)
+endif()
 
 file(MAKE_DIRECTORY ${GEN_HEADER_DIR})
 add_custom_command(OUTPUT ${GEN_HEADER_DIR}/vrb.h 
@@ -32,8 +34,15 @@ add_custom_command(OUTPUT ${GEN_HEADER_DIR}/vrb.h
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_custom_target(generate_header ALL DEPENDS ${GEN_HEADER_DIR}/vrb.h)
 
-add_library(libvrb SHARED ${SOURCE_FILES})
-add_dependencies(libvrb generate_header)
+add_library(vrb SHARED ${SOURCE_FILES})
+add_dependencies(vrb generate_header)
 
 add_executable(vbuf vrb/src/bin/vbuf.c)
-target_link_libraries(vbuf libvrb)
+target_link_libraries(vbuf vrb)
+
+install(TARGETS vrb DESTINATION /usr/lib)
+install(TARGETS vbuf DESTINATION /usr/bin)
+
+if (NOT CMAKE_CROSSCOMPILING)
+install(TARGETS buildheader DESTINATION /usr/bin)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+include_directories(include)
+
+set (SOURCE_FILES
+    vrb/src/lib/vrb/vrb_destroy.c
+    vrb/src/lib/vrb/vrb_empty.c
+    vrb/src/lib/vrb/vrb_get.c
+    vrb/src/lib/vrb/vrb_get_min.c
+    vrb/src/lib/vrb/vrb_give.c
+    vrb/src/lib/vrb/vrb_header.h
+    vrb/src/lib/vrb/vrb_init.c
+    vrb/src/lib/vrb/vrb_lib.h
+    vrb/src/lib/vrb/vrb_move.c
+    vrb/src/lib/vrb/vrb_put_all.c
+    vrb/src/lib/vrb/vrb_put.c
+    vrb/src/lib/vrb/vrb_read.c
+    vrb/src/lib/vrb/vrb_resize.c
+    vrb/src/lib/vrb/vrb_take.c
+    vrb/src/lib/vrb/vrb_uninit.c
+    vrb/src/lib/vrb/vrb_write.c
+    )
+
+add_executable(buildheader CONFIG/buildheader.c)
+
+add_custom_command(OUTPUT include/vrb.h 
+                   COMMAND buildheader include/vrb.h ${SOURCE_FILES} 
+                   DEPENDS buildheader 
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(libvrb SHARED ${SOURCE_FILES} include/vrb.h)
+
+add_executable(vbuf vrb/src/bin/vbuf.c)
+target_link_libraries(vbuf libvrb)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+
 include (GNUInstallDirs)
 
 set (SOURCE_FILES
@@ -38,6 +40,7 @@ install(FILES ${GEN_HEADER_DIR}/vrb.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 
 add_library(vrb SHARED ${SOURCE_FILES})
+set_target_properties(vrb PROPERTIES SOVERSION 0)
 add_dependencies(vrb generate_header)
 
 add_executable(vbuf vrb/src/bin/vbuf.c)


### PR DESCRIPTION
Build both library and vbuf executable using cmake instead of custom configure script.

There is cross-compile support here, in that it will not try to build (or install) the custom build tool `buildheader` for the target architecture -- instead  `buildheader` must already be available (i.e. pre-installed to somewhere on PATH by building this project natively first).